### PR TITLE
Add imperative hooks

### DIFF
--- a/.changeset/smart-mice-march.md
+++ b/.changeset/smart-mice-march.md
@@ -1,0 +1,5 @@
+---
+"@alduino/api-utils": minor
+---
+
+Added `useFetch` and `useFetchDeferred`, which are imperative alternatives to the normal hooks

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "react": "^16 || ^17"
     },
     "dependencies": {
+        "react-async-hook": "^3.6.2",
         "swr": "^1.0.0",
         "tiny-invariant": "^1.1.0",
         "tslib": "^2.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ specifiers:
   lint-staged: ^11.1.2
   prettier: ^2.3.2
   react: ^17.0.2
+  react-async-hook: ^3.6.2
   size-limit: ^5.0.3
   swr: ^1.0.0
   tiny-invariant: ^1.1.0
@@ -26,6 +27,7 @@ specifiers:
   typescript: ^4.4.2
 
 dependencies:
+  react-async-hook: 3.6.2_react@17.0.2
   swr: 1.0.0_react@17.0.2
   tiny-invariant: 1.1.0
   tslib: 2.3.1
@@ -6595,6 +6597,15 @@ packages:
       randombytes: 2.1.0
       safe-buffer: 5.2.1
     dev: true
+
+  /react-async-hook/3.6.2_react@17.0.2:
+    resolution: {integrity: sha512-RkwHCJ8V7I6umKZLHneapuTRWf+eO4LOj0qUwUDsSn27jrAOcW6ClbV3x22Z4hVxH9bA0zb7y+ozDJDJ8PnZoA==}
+    engines: {node: '>=8', npm: '>=5'}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      react: 17.0.2
+    dev: false
 
   /react-is/16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}

--- a/src/api-ctx/ApiContext.tsx
+++ b/src/api-ctx/ApiContext.tsx
@@ -1,10 +1,18 @@
-import {createContext, ReactElement, ReactNode, useContext, useMemo} from "react";
-import ApiContextType from "./ApiContextType";
+import {
+    createContext,
+    ReactElement,
+    ReactNode,
+    useContext,
+    useMemo
+} from "react";
+import {UseAsyncCallbackOptions} from "react-async-hook";
 import {SWRConfiguration} from "swr";
+import ApiContextType from "./ApiContextType";
 
 export interface ApiProviderProps {
     baseUrl: string;
     swrConfig?: SWRConfiguration;
+    fetchConfig?: UseAsyncCallbackOptions<never>;
     children: ReactNode;
 }
 
@@ -20,11 +28,17 @@ export class ApiContextImpl implements ApiContext {
         return useContext(this.context);
     }
 
-    Provider({baseUrl, swrConfig, children}: ApiProviderProps): ReactElement {
+    Provider({
+        baseUrl,
+        swrConfig,
+        fetchConfig,
+        children
+    }: ApiProviderProps): ReactElement {
         const contextValue = useMemo<ApiContextType>(
             () => ({
                 baseUrl,
-                swrConfig: swrConfig ?? {}
+                swrConfig: swrConfig ?? {},
+                fetchConfig: fetchConfig ?? {}
             }),
             [baseUrl, swrConfig]
         );

--- a/src/api-ctx/ApiContextType.ts
+++ b/src/api-ctx/ApiContextType.ts
@@ -1,6 +1,8 @@
+import {UseAsyncCallbackOptions} from "react-async-hook";
 import {SWRConfiguration} from "swr";
 
 export default interface ApiContextType {
     baseUrl: string;
     swrConfig: SWRConfiguration;
+    fetchConfig: UseAsyncCallbackOptions<never>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export type {ApiProviderProps} from "./api-ctx";
 export * from "./swr";
 export type {SWRConfiguration, SWRResponse} from "swr";
 export type {SWRInfiniteConfiguration, SWRInfiniteResponse} from "swr/infinite";
+export type {UseAsyncCallbackOptions, UseAsyncReturn} from "react-async-hook";

--- a/src/swr/Endpoint.ts
+++ b/src/swr/Endpoint.ts
@@ -1,5 +1,5 @@
-import {RequestWithBody, RequestWithOptionalBody} from "./RequestWithBody";
 import ApiContext from "../api-ctx";
+import {RequestWithBody, RequestWithOptionalBody} from "./RequestWithBody";
 
 type Fetch<Request, Response> = Request extends RequestWithBody<infer Body>
     ? (url: string, body: Body) => Response | Promise<Response>

--- a/src/swr/hooks.ts
+++ b/src/swr/hooks.ts
@@ -1,9 +1,15 @@
 import {useCallback, useMemo} from "react";
+import {
+    useAsyncCallback,
+    UseAsyncCallbackOptions,
+    UseAsyncReturn
+} from "react-async-hook";
 import useSWR, {KeyLoader, SWRConfiguration, SWRResponse} from "swr";
 import useSWRInfinite, {SWRInfiniteResponse} from "swr/infinite";
 import invariant from "tiny-invariant";
 import Endpoint from "./Endpoint";
 import RequestLoader from "./RequestLoader";
+import {isRequestWithBody, RequestWithBody} from "./RequestWithBody";
 import getRequestArguments from "./getRequestArguments";
 import getUrlFromEndpoint from "./getUrlFromEndpoint";
 
@@ -86,4 +92,65 @@ export function useSwrInfinite<Request, Response>(
     );
 
     return useSWRInfinite(url, endpoint.fetch, {...swrConfig, ...config});
+}
+
+/**
+ * Runs the request when the callback is executed (using `react-async-hook`'s `useAsyncCallback`)
+ * @param endpoint The endpoint to send the request to
+ * @param request Data for the request
+ * @param config Extra configuration for `useAsyncCallback`
+ * @param _fnName Internal parameter for library usage only
+ */
+export function useFetch<Request, Response>(
+    endpoint: Endpoint<Request, Response>,
+    request: Request | null | (() => Request | null),
+    config?: UseAsyncCallbackOptions<Response>,
+    _fnName = "useFetch"
+): UseAsyncReturn<Response | null> {
+    type Body = Request extends RequestWithBody<infer Body> ? Body : never;
+
+    const ctx = endpoint.apiContext.use();
+    invariant(
+        ctx !== null,
+        `${_fnName} is being used in a component that is not wrapped by <ApiProvider />`
+    );
+    const {baseUrl, fetchConfig} = ctx;
+
+    const fullConfig = useMemo(
+        () => ({
+            ...fetchConfig,
+            ...config
+        }),
+        [fetchConfig, config]
+    ) as UseAsyncCallbackOptions<Response | null>;
+
+    const args = useMemo(() => {
+        if (request === null) return null;
+
+        if (typeof request === "function") {
+            return () => {
+                const req = (request as () => Request)();
+                if (req === null) return null;
+                const url = getUrlFromEndpoint(endpoint, req, baseUrl);
+                if (isRequestWithBody(req))
+                    return [url, req.body] as [string, Body];
+                return [url] as [string, Body?];
+            };
+        } else {
+            const url = getUrlFromEndpoint(endpoint, request, baseUrl);
+            if (isRequestWithBody(request))
+                return [url, request.body] as [string, Body];
+            return [url] as [string, Body?];
+        }
+    }, [request, endpoint, baseUrl]);
+
+    const fn = useCallback(async () => {
+        if (request === null) return null;
+        const argsVal = typeof args === "function" ? args() : args;
+        if (argsVal === null) return null;
+
+        return await endpoint.fetch(...argsVal);
+    }, [args, endpoint]);
+
+    return useAsyncCallback<Response | null>(fn, fullConfig);
 }

--- a/src/swr/hooks.ts
+++ b/src/swr/hooks.ts
@@ -107,7 +107,7 @@ export function useFetch<Request, Response>(
     request: Request | null | (() => Request | null),
     config?: UseAsyncCallbackOptions<Response>,
     _fnName = "useFetch"
-): UseAsyncReturn<Response | null> {
+): UseAsyncReturn<Response | null, []> {
     type Body = Request extends RequestWithBody<infer Body> ? Body : never;
 
     const ctx = endpoint.apiContext.use();
@@ -153,7 +153,7 @@ export function useFetch<Request, Response>(
         return await endpoint.fetch(...argsVal);
     }, [args, endpoint]);
 
-    return useAsyncCallback<Response | null>(fn, fullConfig);
+    return useAsyncCallback<Response | null, []>(fn, fullConfig);
 }
 
 /**


### PR DESCRIPTION
Adds `useFetch` and `useFetchDeferred`, which are imperative alternatives to the normal hooks, which use `useAsyncCallback` from `react-async-hook` instead of `swr`.

Instead of instantly running the request, these both return `{execute}` functions which run it when called. This is more useful for requests that update data on the server, as you generally want to do this once at a well-defined time, without caching or re-requesting.