### PR TITLE
Export ApiContext type

### DIFF
--- a/.changeset/strange-planets-kick.md
+++ b/.changeset/strange-planets-kick.md
@@ -1,0 +1,5 @@
+---
+"@alduino/api-utils": patch
+---
+
+Export ApiContext type so that createContext() can be used with Typescript

--- a/src/api-ctx/index.ts
+++ b/src/api-ctx/index.ts
@@ -1,4 +1,3 @@
 export type {default as ApiContextType} from "./ApiContextType";
 export {default as createContext} from "./create";
-export * from "./ApiContext";
-export type {default} from "./ApiContext";
+export type {default, ApiProviderProps} from "./ApiContext";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export {default as key} from "./key";
 export type {Param, ParamRecord} from "./key";
 export {createContext} from "./api-ctx";
-export type {ApiProviderProps} from "./api-ctx";
+export type {default as ApiContext, ApiProviderProps} from "./api-ctx";
 export * from "./swr";
 export type {SWRConfiguration, SWRResponse} from "swr";
 export type {SWRInfiniteConfiguration, SWRInfiniteResponse} from "swr/infinite";


### PR DESCRIPTION
Fixes #6

So that `createContext()` can be used with Typescript