### PR TITLE
Add a request function for use outside of React

### DIFF
--- a/.changeset/funny-ads-vanish.md
+++ b/.changeset/funny-ads-vanish.md
@@ -1,0 +1,5 @@
+---
+"@alduino/api-utils": minor
+---
+
+Added an SSR compatible request function that doesn't use React contexts or hooks. If you implement this function, you should use a request function that is compatible with both the browser and a Node context (like [`cross-fetch`](https://www.npmjs.com/package/cross-fetch)).

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ With this form, you generate functions that wrap `useSwr`, `useFetch`, and `useF
 to it automatically. The generated code might look something like:
 
 ```typescript
-import {useSwr, SWRConfiguration, SWRResponse} from "@alduino/api-utils";
+import {useSwr, useFetch, useFetchDeferred, sendRequest, SWRConfiguration, SWRResponse} from "@alduino/api-utils";
 
 export function useUserAvatar(
     request: Request,
@@ -112,6 +112,10 @@ export function useUserAvatarFetchDeferred(
         config,
         "useUserAvatarFetchDeferred"
     );
+}
+
+export function sendUserAvatarRequest(baseUrl: string, request: Request): Promise<Response> {
+    return sendRequest(userAvatarEndpoint, baseUrl, request);
 }
 ```
 


### PR DESCRIPTION
This function does not have access to the `baseUrl` from the `ApiProvider`, so it needs to be passed in with each call.