### PR TITLE
Add functions to get the endpoint URL

### DIFF
--- a/.changeset/young-mayflies-watch.md
+++ b/.changeset/young-mayflies-watch.md
@@ -1,0 +1,5 @@
+---
+"@alduino/api-utils": minor
+---
+
+Added functions to get the URL that a request would be sent to. These are useful for example if your API serves an image, so you can set it as the `src` instead of a blob.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,12 +11,10 @@ jobs:
               uses: pnpm/action-setup@v2
               with:
                 version: 6.16.0
-                run_install: true
             - name: Size limit
-              uses: andresz1/size-limit-action@v1
+              uses: andresz1/size-limit-action@78c7b30a17ebe6fb0df6ef98400f8a6117676f33
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
-                  skip_step: install
     test:
         timeout-minutes: 15
         runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -4,23 +4,18 @@ This library contains a collection of utilities to build an API client.
 
 ## Tutorial
 
-> This library is designed to be used by machine-generated code (i.e. swagger-codegen).
-> It is probably going to be very tedious to write a library using it by hand.
+> This library is designed to be used by machine-generated code (i.e. swagger-codegen). It is probably going to be very tedious to write a library using it by hand.
 
 ### Re-exports
 
-First off, there are some things you should re-export from the library, as they are meant for use by your library's
-user.
+First off, there are some things you should re-export from the library, as they are meant for use by your library's user.
 
-- `useSwr`, `useSwrInfinite`, `useFetch`, `useFetchDeferred`: These hooks are the core of how your API will be used. If
-  you use wrapper functions, you don't need to export these.
-- `SWRConfiguration`, `SWRResponse`, `SWRInfiniteConfiguration`, `SWRInfiniteResponse`: Theses are various types used
-  by `useSwr` (re-exported from the `swr` library)
+- `useSwr`, `useSwrInfinite`, `useFetch`, `useFetchDeferred`, `sendRequest`, `getEndpointUrl`, `useEndpointUrl`: These hooks and functions are the core of how your API will be used. If you use [wrapper functions](#wrapper-functions), you don't need to export these.
+- `SWRConfiguration`, `SWRResponse`, `SWRInfiniteConfiguration`, `SWRInfiniteResponse`, `UseAsyncCallbackOptions`, `UseAsyncReturn`: Theses are various types used by `useSwr` and `useFetch` (re-exported from the `swr` and `react-async-hook` libraries)
 
 ### Usage
 
-The library revolves around `Endpoint`s. These are how your library maps some request data to a URL to send the actual
-request to.
+The library revolves around `Endpoint`s. These are how your library maps some request data to a URL to send the actual request to.
 
 An endpoint implementation would look something like:
 
@@ -51,14 +46,11 @@ export const userAvatarEndpoint: Endpoint<Request, Response> = {
 };
 ```
 
-You can generate the `Request` interface by merging the URL parameters and the query parameters, then split them back
-out again via object destructuring in `getKey()`.
+You can generate the `Request` interface by merging the URL parameters and the query parameters, then split them back out again via object destructuring in `getKey()`.
 
 #### API Context
 
-Notice the `apiContext` key in the endpoint above. This is an "API Context", which is what api-utils uses to map your
-keys to a full URL, as well as a way for a user to specify configuration for swr. The API context is based off of React
-Contexts.
+Notice the `apiContext` key in the endpoint above. This is an "API Context", which is what api-utils uses to map your keys to a full URL, as well as a way for a user to specify configuration for swr. The API context is based off of React Contexts.
 
 In a file that can be imported by any endpoint files, add this code (it can be a static file, no generation is needed):
 
@@ -71,21 +63,17 @@ export const ApiProvider = context.Provider;
 
 The `apiContext` export should then be used as the `apiContext` value you saw in the endpoint example above.
 
-You need to export the `ApiProvider` to users of your library, as it is how they specify required configuration like the
-base URL.
+You need to export the `ApiProvider` to users of your library, as it is how they specify required configuration like the base URL.
 
 ### Library API
 
-There are two forms your library's API can take: wrapper functions (recommended), or exposed endpoints. Wrapper
-functions are recommended because they provide a better DX.
+There are two forms your library's API can take: wrapper functions (recommended), or exposed endpoints. Wrapper functions are recommended because they provide a better DX.
 
 #### Wrapper functions
 
-> This form is recommended for better DX and API safety - each endpoint has its own hook, and it is not possible
-> to `useInfinite` where it doesn't make sense.
+> This form is recommended for better DX and API safety - each endpoint has its own hook, and it is not possible to `useInfinite` where it doesn't make sense.
 
-With this form, you generate functions that wrap `useSwr`, `useFetch`, and `useFetchDeferred`, and provide the endpoint
-to it automatically. The generated code might look something like:
+With this form, you generate functions that wrap `useSwr`, `useFetch`, and `useFetchDeferred`, and provide the endpoint to it automatically. The generated code might look something like:
 
 ```typescript
 import {useSwr, useFetch, useFetchDeferred, sendRequest, SWRConfiguration, SWRResponse} from "@alduino/api-utils";
@@ -117,10 +105,17 @@ export function useUserAvatarFetchDeferred(
 export function sendUserAvatarRequest(baseUrl: string, request: Request): Promise<Response> {
     return sendRequest(userAvatarEndpoint, baseUrl, request);
 }
+
+export function getUserAvatarEndpointUrl(baseUrl: string, request: Omit<Request, "body">): string {
+    return getEndpointUrl(userAvatarEndpoint, baseUrl, request);
+}
+
+export function useUserAvatarEndpointUrl(request: Omit<Request, "body">): string {
+    return useEndpointUrl(userAvatarEndpoint, request, "useUserAvatarEndpointUrl");
+}
 ```
 
-Note the last parameter passed, this value should be the same as the name of your wrapper function, to provide better
-error messages.
+Note the last parameter passed, this value should be the same as the name of your wrapper function, to provide better error messages.
 
 This can then be consumed as:
 
@@ -139,9 +134,7 @@ You should also generate `useSwrInfinite` versions where relevant.
 
 #### Exposed endpoints
 
-If you do not want to generate wrapper functions, you can export your `Endpoint` values as well as the `useSwr`,
-`useSwrInfinite`, `useFetch`, and `useFetchDeferred` functions provided by this library. A user of your library can then
-call `useSwr` directly:
+If you do not want to generate wrapper functions, you can export your `Endpoint` values as well as the `useSwr`, `useSwrInfinite`, `useFetch`, and `useFetchDeferred` functions provided by this library. A user of your library can then call `useSwr` directly:
 
 ```typescript
 import {useSwr, userAvatarEndpoint} from "my-api-client";
@@ -157,24 +150,20 @@ Tells the library how and where to send a request. An `Endpoint` has three keys:
 
 #### `apiContext`
 
-This is the React context returned from `createContext()` that specifies information like the base URL and default
-request options.
+This is the React context returned from `createContext()` that specifies information like the base URL and default request options.
 
 #### `getKey(request: Request)`
 
 This function should convert the request into a URL, relative to the base URL (i.e. should not start with a `/`).
 
-It is recommended that you use the `key` function for this, it makes it much neater. It’s also easy to generate code
-for.
+It is recommended that you use the `key` function for this, it makes it much neater. It’s also easy to generate code for.
 
 #### `fetch(url: string, [body: Body])`
 
-This function should send the actual request to the URL provided. The URL is created from the base URL passed to
-the `ApiProvider` as well as the return value of this endpoint’s `getKey` function.
+This function should send the actual request to the URL provided. The URL is created from the base URL passed to the `ApiProvider` as well as the return value of this endpoint’s `getKey` function.
 
 Any other request options (method, cookies etc) should be hardcoded in the call here.
 
 ##### Body parameter
 
-If a request requires a body parameter, set it as a field called `body` in the `Request` type. If this field exists, its
-value will be passed to this function as a second parameter.
+If a request requires a body parameter, set it as a field called `body` in the `Request` type. If this field exists, its value will be passed to this function as a second parameter.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-module.exports = {
+export default {
     preset: 'ts-jest',
     testEnvironment: 'node'
 };

--- a/package.json
+++ b/package.json
@@ -40,12 +40,7 @@
     },
     "size-limit": [
         {
-            "path": "dist/index.prod.min.js",
-            "limit": "10 kb"
-        },
-        {
-            "path": "index.esm.js",
-            "limit": "10 kb"
+            "path": "index.js"
         }
     ],
     "jest-junit": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     },
     "size-limit": [
         {
-            "path": "index.js"
+            "path": "dist/index.js"
         }
     ],
     "jest-junit": {


### PR DESCRIPTION
This PR adds two new functions to be used/exported by libraries, which allows a user to get the URL that a request would be sent to, without actually sending the request.

- `useEndpointUrl`: A hook that returns basically the result of an endpoint's `getKey` function, but with the base URL added.
- `getEndpointUrl`: The same as above, but not as a hook. This means it doesn't have access to the configuration context, so the base URL needs to be passed in manually.

These are useful for example if your API serves an image, so you can set the result of one of these functions as the `src`.

## Example

```js
const endpoint = {
    getKey({urlParam, queryParam}) {
        return key`api/endpoint/${urlParam}?${{queryParam}}`;
    }
};

getEndpointUrl(endpoint, "https://example.com/", {
    urlParam: "test-url-param",
    queryParam: "test-query-param"
});
// => https://example.com/api/endpoint/test-url-param?queryParam=test-query-param
```